### PR TITLE
#39 css modify

### DIFF
--- a/app/assets/style/object/project/_detail-pc.scss
+++ b/app/assets/style/object/project/_detail-pc.scss
@@ -128,6 +128,18 @@ padding-top: 60px;
       }
     }
 
+    &__textarea{
+      margin: 20px 0;
+      textarea{
+        border: solid #e5e5e5 1px;
+        border-radius: 4px;
+        outline: none;
+        text-align: left;
+        font-weight: 300;
+        width: 300px;
+      }
+    }
+
     &__btns{
     margin-top: 10px;
     display: flex;

--- a/app/assets/style/object/project/_detail-sp.scss
+++ b/app/assets/style/object/project/_detail-sp.scss
@@ -139,6 +139,17 @@ margin: floor-decimal(15vw * 100 / 375, 2) auto 0;
       }
     }
 
+    &__textarea{
+      margin-top: 10px;
+      textarea{
+        border: solid #e5e5e5 1px;
+        border-radius: 4px;
+        outline: none;
+        text-align: left;
+        width:75%;
+      }
+    }
+
     &__btns{
     //margin-top: floor-decimal(20vw * 100 / 375, 2);
     }
@@ -169,5 +180,9 @@ margin: floor-decimal(15vw * 100 / 375, 2) auto 0;
 
   }
 
+}
+
+.v-input__control{
+  margin: 0 auto;
 }
 

--- a/app/assets/style/object/project/_order-pc.scss
+++ b/app/assets/style/object/project/_order-pc.scss
@@ -13,6 +13,13 @@
   box-shadow: 0px 3px 4px rgba(0, 0, 0, 0.16);
   text-align: center;
   }
+  &__img{
+    text-align: center;
+    img{
+      width: 800px;
+      margin-top: 30px;
+    }
+  }
 
   &__name{
   font-size: 36px;
@@ -89,13 +96,12 @@
   }
 
   &__action{
-  margin-top: 50px;
     &__btn{
     width: 9em;
     font-size: 18px;
     line-height: 1.5;
     font-weight: 900;
-    margin: 0 auto 0;
+    margin: 15px auto;
     border-radius: 4px;
     padding: 0.25em 0 0.45em;
     text-align: center;
@@ -197,7 +203,7 @@ background: rgba(0,0,0,0.5);
   color: #fff;
   cursor: pointer;
   transition: all 0.3s ease;
-    
+
     &:hover{
     opacity: 0.5;
     }
@@ -209,7 +215,7 @@ background: rgba(0,0,0,0.5);
   top: 8px;
   cursor: pointer;
   transition: all 0.3s ease;
-    
+
     &:hover{
     opacity: 0.5;
     }
@@ -219,7 +225,7 @@ background: rgba(0,0,0,0.5);
     width: 29px;
     height: 29px;
     transform: rotate(45deg);
-    
+
       &::before{
       content: '';
       position: absolute;
@@ -245,4 +251,7 @@ background: rgba(0,0,0,0.5);
 
 }
 
-
+//Vuetifyのデフォルトを上書きしました。
+.v-input__control{
+  margin: 0 auto;
+}

--- a/app/assets/style/object/project/_order-sp.scss
+++ b/app/assets/style/object/project/_order-sp.scss
@@ -14,6 +14,12 @@ margin: floor-decimal(15vw * 100 / 375, 2) auto 0;
   //display: flex;
   }
 
+  &__img{
+    img{
+      width: 100%;
+    }
+  }
+
   &__name{
   //margin-top: floor-decimal(30vw * 100 / 375, 2);
   font-size: floor-decimal(24vw * 100 / 375, 2);
@@ -100,7 +106,6 @@ margin: floor-decimal(15vw * 100 / 375, 2) auto 0;
   }
 
   &__action{
-  margin-top: floor-decimal(20vw * 100 / 375, 2);
   text-align: center;
     &__price{
     font-size: floor-decimal(32vw * 100 / 375, 2);
@@ -124,7 +129,7 @@ margin: floor-decimal(15vw * 100 / 375, 2) auto 0;
     font-size: floor-decimal(18vw * 100 / 375, 2);
     line-height: 1.5;
     font-weight: 900;
-    margin: floor-decimal(20vw * 100 / 375, 2) auto 0;
+    margin: floor-decimal(10vw * 100 / 375, 2) auto 0;
     border-radius: ceil-decimal(4vw * 100 / 375, 2);
     padding: 0.25em 0 0.45em;
     text-align: center;
@@ -229,7 +234,7 @@ background: rgba(0,0,0,0.5);
     width: 29px;
     height: 29px;
     transform: rotate(45deg);
-    
+
       &::before{
       content: '';
       position: absolute;
@@ -263,8 +268,3 @@ background: rgba(0,0,0,0.5);
   }
 
 }
-
-
-
-
-

--- a/app/pages/_lang/ck/_id.vue
+++ b/app/pages/_lang/ck/_id.vue
@@ -21,23 +21,39 @@
                   ><input type="text" v-model="price" id="amount" /> ETH</label
                 >
               </div>
+              <div class="l-item__action__textarea">
+                <div>{{ $t('id.option') }}</div>
+              <textarea
+                v-model="msg"
+                name=""
+                id=""
+                box
+                auto-grow
+                placeholder = "一言メッセージを記入できます"
+              >
+              </textarea>
+              </div>
+
+              <!--
               <v-expansion-panel>
                 <v-expansion-panel-content>
-                  <div slot="header">{{ $t('id.option') }}</div>
+                  <div slot="header" class="text-xs-center">{{ $t('id.option') }}</div>
                   <v-card>
-                    <p>{{ $t('id.inputMessage') }}</p>
-                    <div>
+                    <p class="text-xs-center">{{ $t('id.inputMessage') }}</p>
+                    <v-container fluid grid-list-md>
+                      <div class="l-item__action__textarea">
                       <textarea
                         v-model="msg"
                         name=""
                         id=""
-                        cols="30"
-                        rows="10"
+                        box
+                        auto-grow
                       ></textarea>
-                    </div>
+                      </div>
+                    </v-container>
                   </v-card>
                 </v-expansion-panel-content>
-              </v-expansion-panel>
+              </v-expansion-panel> -->
               <div v-if="owned">
                 <div class="l-item__action__btns" v-if="!approved">
                   <v-btn

--- a/app/pages/_lang/ck/order/_hash.vue
+++ b/app/pages/_lang/ck/order/_hash.vue
@@ -1,15 +1,24 @@
 <template>
 <div>
     <section class="l-information">
-      <div ><img class="ogpimg" :src="order.ogp" width=100%></div>
+      <div class=l-information__img><img class="ogpimg" :src="order.ogp"></div>
       <div class="l-information__frame" v-if="order.valid">
         <div class="l-information__name">{{ order.metadata.name}} / Gen.{{ order.metadata.generation}}</div>
         <div class="l-information__txt"># {{ order.metadata.id}}</div>
         <div class="l-information__txt">Crypto Kitties</div>
-        <v-form v-model="valid">
+        <v-form v-model="valid" class="center">
+          <v-flex center>
+            <v-checkbox
+              class="center"
+              v-model="checkbox"
+              :rules="[v => !!v || '']"
+              label="利用規約に同意する"
+              required
+            ></v-checkbox>
+          </v-flex>
         <div class="l-information__action">
           <v-btn
-          class="l-information__action__btn"
+          class="l-information__action__btn white_text"
           color="#3498db"
           large
           @click="purchase"
@@ -20,24 +29,17 @@
             ></v-progress-circular>
           </v-btn>
       </div>
-       <v-flex center>
-            <v-checkbox
-              class="center"
-              v-model="checkbox"
-              :rules="[v => !!v || '']"
-              label="利用規約に同意する"
-              required
-            ></v-checkbox>
-        </v-flex>
+
         </v-form>
-    </div>
-    <div class="l-information__action__btn" v-if="order.valid">
+      <div class="l-information__action__btn" v-if="order.valid">
        <a :href="'https://twitter.com/share?url=https://bazaaar.io/ck/order/' + order.hash +
         '&text=' + '出品されました! '+ order.metadata.name  + '/ Gen.' + order.metadata.generation +
         '&hashtags=bazaaar, バザール, CryptoKitties'" class="twitter-share-button" data-size="large" data-show-count="false" target=”_blank”>
         Tweetする
         </a>
+      </div>
     </div>
+
     </section>
     <section class="c-index c-index--recommend" v-if="recommend.lengh">
         <h2 class="c-index__title">関連アセット</h2>
@@ -175,8 +177,13 @@ color: white;
   padding: 10px 0;
   margin: auto;
 }
-.ogpimg{
 
+.white_text {
+  color: white;
+}
+
+.v-input__control{
+  margin: 0 auto;
 }
 </style>
 


### PR DESCRIPTION
### PC表示
* [x]  _hashのOGP画像を小さくする
* [ ]  関連アセット部の干渉を修正する

### PC,SP共通
* [x]  利用規約チェック中央に配置する　※Vuetifyを上書き、PC表示で中央揃えになってしまっている
* [x]  一言メッセージのcssデザインに合わせる
* [ ]  メニューバーのレイアウトが悪い
* [ ]  Footerの配置をロード時最適化する
* [ ]  オリジナルのCSSとVuetifyの質感が違う

追加で残件
* [ ]OrderのツイートボタンをTwitterアイコンにする