### PR TITLE
Update Default Relayers for Out of the Box Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ $ npm run dev
 2. Open the `nuxt.config.ts`file and edit service name etc.
 
 3. Launch a [0x-launch-kit-backend](https://github.com/0xProject/0x-launch-kit-backend). If you want to open Market quicly, you can use Satellites relayer.
-    -  mainnet : `https://relayer-mainnet.nftsatellites.com/v2/`
-    - rinkeby : `https://relayer-rinkeby.nftsatellites.com/v2/`
+    -  mainnet : `https://api.0x.org/sra/`
+    - kovan : `https://kovan.api.0x.org/`
 
 
 ## Supporting Satellites

--- a/templates/plugins/config.ts
+++ b/templates/plugins/config.ts
@@ -1,5 +1,5 @@
 const networkId = 1
-const relayer = 'https://relayer-mainnet.nftsatellites.com/v2/'
+const relayer = 'https://api.0x.org/sra/'
 const ga = 'UA-130401695-4'
 const feeBase = 10000
 const feePer = 100


### PR DESCRIPTION
I saw that the default relayer was 404ing and the repository linked has been deprecated, so I repointed the default to the SRA, the undeprecated public SRA API